### PR TITLE
This should add requested functionality in #4

### DIFF
--- a/_plugins/flickr_photoset.rb
+++ b/_plugins/flickr_photoset.rb
@@ -95,15 +95,15 @@ module Jekyll
     def generate_photo_data(photoset, flickrConfig)
       returnSet = Array.new
 
-      FlickRaw.api_key       = flickrConfig['api_key']
-      FlickRaw.shared_secret = flickrConfig['shared_secret']
-      flickr.access_token    = flickrConfig['access_token']
-      flickr.access_secret   = flickrConfig['access_secret']
+      FlickRaw.api_key       = ENV['FLICKR_API_KEY'] || flickrConfig['api_key']
+      FlickRaw.shared_secret = ENV['FLICKR_SHARED_SECRET'] || flickrConfig['shared_secret']
+      flickr.access_token    = ENV['FLICKR_ACCESS_TOKEN'] || flickrConfig['access_token']
+      flickr.access_secret   = ENV['FLICKR_ACCESS_SECRET'] || flickrConfig['access_secret']
 
       begin
         flickr.test.login
       rescue Exception => e
-        raise "Bad token: #{flickrConfig['access_token']}"
+        raise "Unable to login, please check documentation for correctly configuring Environment Variables, or _config.yaml."
       end
 
       begin


### PR DESCRIPTION
Added option to use Environment variables to collect the flickr API information.  If this information is not stored there, it will look in the _config.yaml file, and if not there, login will fail, and error will occur.
